### PR TITLE
Some possible optimizations.

### DIFF
--- a/benchmark/Benchmark.cs
+++ b/benchmark/Benchmark.cs
@@ -95,7 +95,7 @@ namespace SimdUnicodeBenchmarks
                             {
                                 utf8[position + 1] = (byte)((utf8[position + 1] & 0b11000011) | (s << 2));
                                 errorIntroduced = true;
-                                break; // Just introduce one surrogate error
+                                break; // Just introduce one surrogate error // TODO: having a loop that breaks immediately does not make much sense !!!!!!!!!!!!!!!!!!!!!!
                             }
                         }
                         break;
@@ -433,7 +433,7 @@ namespace SimdUnicodeBenchmarks
                 @"data/turkish.utf8.txt",
                 @"data/german.utf8.txt",
                 @"data/japanese.utf8.txt")]
-        public string FileName;
+        public string? FileName;
 
         private string[] _lines = Array.Empty<string>();
         private byte[][] _linesUtf8 = Array.Empty<byte[]>();
@@ -607,7 +607,7 @@ namespace SimdUnicodeBenchmarks
             }
 
             // Create a BenchmarkDotNet config with a custom maximum parameter column width
-            var config = DefaultConfig.Instance.With(SummaryStyle.Default.WithMaxParameterColumnWidth(100));
+            var config = DefaultConfig.Instance.With(summaryStyle: SummaryStyle.Default.WithMaxParameterColumnWidth(100));
 
             // Check if a specific argument (e.g., "runall") is provided
             if (args.Length > 0 && args[0] == "runall")


### PR DESCRIPTION
This is a PR over AVX2_UTF8_validation. Merging this would change the branch AVX2_UTF8_validation.

Note that I may have introduced bugs, you should review carefully.

Mostly, I have been going through Visual Studio and applying recommended changes (we have a bunch of naming violation), and I have also examined the assembly. For all functions where the assembly looked good, I have included it as a comment. 

There are problematic cases that I solved using static functions. E.g., before making it static, :IsIncomplete was this monster:


```asm
; Assembly listing for method SimdUnicode.Utf8Validation+utf8_checker:IsIncomplete(System.Runtime.Intrinsics.Vector256`1[ubyte]):System.Runtime.Intrinsics.Vector256`1[ubyte] (FullOpts)
; Emitting BLENDED_CODE for X64 with AVX512 - Windows
; FullOpts code
; optimized code
; rsp based frame
; partially interruptible
; No PGO data
; 0 inlinees with PGO data; 0 single block inlinees; 1 inlinees without PGO data

G_M000_IG01:                ;; offset=0x0000
       push     rsi
       push     rbx
       sub      rsp, 40
       vzeroupper 
       mov      rsi, rcx
       mov      rbx, rdx
 
G_M000_IG02:                ;; offset=0x000F
       test     byte  ptr [(reloc 0x7ff850780950)], 1
       je       SHORT G_M000_IG05
 
G_M000_IG03:                ;; offset=0x0018
       mov      rax, 0x237000016D8
       vmovups  ymm0, ymmword ptr [rax]
       vmovups  ymm1, ymmword ptr [rbx]
       vpsubusw ymm0, ymm1, ymm0
       vmovups  ymmword ptr [rsi], ymm0
       mov      rax, rsi
 
G_M000_IG04:                ;; offset=0x0035
       vzeroupper 
       add      rsp, 40
       pop      rbx
       pop      rsi
       ret      
 
G_M000_IG05:                ;; offset=0x003F
       mov      rcx, 0x7FF850780918
       mov      edx, 8
       call     CORINFO_HELP_GETSHARED_NONGCSTATIC_BASE
       jmp      SHORT G_M000_IG03
 
; Total bytes of code 85
```


If you look at the `IsIncomplete `method, it should not generate so much code.

One issue that might be expensive is the way we handle the tail with a stackalloc. This seems to trigger all sorts of extra assembly instructions and it may be a bit expensive. I am not sure I know how to do better.

Importantly, I recommend moving the code into a new SIMD function and only calling it when the input is long enough.

In any case, I recommend using https://marketplace.visualstudio.com/items?itemName=EgorBogatov.Disasmo&ssr=false#overview if possible... 

