### PR TITLE
example: illustrate how we might count the number of characters of each type

### DIFF
--- a/src/UTF8.cs
+++ b/src/UTF8.cs
@@ -264,6 +264,7 @@ namespace SimdUnicode
                     int asciibytes = 0; // number of ascii bytes in the block (could also be called n1)
                     int contbytes = 0; // number of continuation bytes in the block
                     int n4 = 0; // number of 4-byte sequences that start in this block
+                    int totalbyte, n3, n2;
  
                     for (; processedLength + 16 <= inputLength; processedLength += 16)
                     {
@@ -278,15 +279,15 @@ namespace SimdUnicode
                             if (Sse2.MoveMask(prevIncomplete) != 0)
                             {
                                 // The block goes from start_point to processedLength.
-                                int totalbyte = processedLength - start_point;
+                                totalbyte = processedLength - start_point;
                                 // We need to adjust the length so that it would include
                                 // a complete character. Because if we fail right away,
                                 // it is unsafe to call adjustmentFactor.
                                 if(totalbyte > 0) {
                                     totalbyte += adjustmentFactor(pInputBuffer + processedLength);
                                 }
-                                int n3 = asciibytes - 2 * n4 + 2 * contbytes - totalbyte;
-                                int n2 = -2 * asciibytes + n4 - 4 * contbytes + 2 * totalbyte;
+                                n3 = asciibytes - 2 * n4 + 2 * contbytes - totalbyte;
+                                n2 = -2 * asciibytes + n4 - 4 * contbytes + 2 * totalbyte;
                                 /***
                                 * So we have that n2 is the number of 2-byte sequences that begins in the
                                 * block,
@@ -320,15 +321,15 @@ namespace SimdUnicode
                             if (Sse2.MoveMask(error) != 0)
                             {
                                 // The block goes from start_point to processedLength.
-                                int totalbyte = processedLength - start_point;
+                                totalbyte = processedLength - start_point;
                                 // We need to adjust the length so that it would include
                                 // a complete character. Because if we fail right away,
                                 // it is unsafe to call adjustmentFactor.
                                 if(totalbyte > 0) {
                                     totalbyte += adjustmentFactor(pInputBuffer + processedLength);
                                 }
-                                int n3 = asciibytes - 2 * n4 + 2 * contbytes - totalbyte;
-                                int n2 = -2 * asciibytes + n4 - 4 * contbytes + 2 * totalbyte;
+                                n3 = asciibytes - 2 * n4 + 2 * contbytes - totalbyte;
+                                n2 = -2 * asciibytes + n4 - 4 * contbytes + 2 * totalbyte;
                                 /***
                                 * So we have that n2 is the number of 2-byte sequences that begins in the
                                 * block,
@@ -352,15 +353,15 @@ namespace SimdUnicode
                         // and no expensive operation:
                         asciibytes += 16 - mask; // count the number of ascii bytes
                     }
-                    int totalbyte = processedLength - start_point;
+                    totalbyte = processedLength - start_point;
                     // We need to adjust the length so that it would include
                     // a complete character. Because if we fail right away,
                     // it is unsafe to call adjustmentFactor.
                     if(totalbyte > 0) {
                         totalbyte += adjustmentFactor(pInputBuffer + processedLength);
                     }
-                    int n3 = asciibytes - 2 * n4 + 2 * contbytes - totalbyte;
-                    int n2 = -2 * asciibytes + n4 - 4 * contbytes + 2 * totalbyte;
+                    n3 = asciibytes - 2 * n4 + 2 * contbytes - totalbyte;
+                    n2 = -2 * asciibytes + n4 - 4 * contbytes + 2 * totalbyte;
                     /***
                      * So we have that n2 is the number of 2-byte sequences that begins in the
                      * block,


### PR DESCRIPTION
This is not for merging, but it shows that we can efficiently compute the number of 4-byte, 3-byte, 2-byte, 1-byte (ascii) characters **starting** in the 'block' where the block is the region from where we start the non-trivial SIMD processing, up to either the end of the SIMD-based loop (if there is no error) or the exit location (if there is an error). I only coded it for the Sse code, but it is easy enough and can be ported to the other functions.

The trick is that we don't need to compute everything. We only need ...

1. The ASCII characters. We get that almost for free.
2. The continuation characters. We get it almost for free.
3. And the 4-byte starting characters (this is cheap).

So we do a bit of algebra.


Suppose that we have processed length bytes.  Importantly, we are going to assume that length includes everything up to the end of the last character. If the block ends with a character that gets truncated, we may need to add 0, 1, 2 or 3 bytes for the formula to work out

So we have...

 ` length = 4 * n4 + 3 * n3 + 2 * n2 + n1`

where n1 is the number of 1-byte sequences (ASCII), n2 is the number of 2-byte sequences, n3 is the number of 3-byte sequences, and n4 is the number of 4-byte sequences.

Let ncon be the number of continuation bytes, then we have

 ` length =  n4 + n3 + n2 + ncon + n1`

We can solve for n2 and n3 in terms of the other variables:
 
`n3 = n1 - 2 * n4 + 2 * ncon - length`

 `n2 = -2 * n1 + n4 - 4 * ncon + 2 * length`


Thus we only need to count the number of continuation bytes, the number of ASCII bytes and the number of 4-byte sequences.

I have not actually tested the code, I have just written and documented it.

I think it is relatively clean and efficient. Even if there are bugs in my implementation, they should be easy to debug.