### PR TITLE
fix: optimize the ARM function for systems with weak SIMD performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,21 +145,21 @@ faster than the standard library.
 | Latin-Lipsum    |  87        | 38                        | 2.3 x           |
 | Russian-Lipsum  |  7.4       | 2.7                       | 2.7 x           |
 
-On a Neoverse V1 (Graviton 3), our validation function is 1.3 to over four times
+On a Neoverse V1 (Graviton 3), our validation function is 1.3 to over five times
 faster than the standard library.
 
 | data set      | SimdUnicode speed (GB/s) | .NET speed (GB/s) |  speed up |
 |:----------------|:-----------|:--------------------------|:-------------------|
-| Twitter.json    |  12        | 8.7                        | 1.4 x           |
-| Arabic-Lipsum   |  3.4       | 2.0                       | 1.7 x           |
-| Chinese-Lipsum  |  3.4       | 2.6                       | 1.3 x           |
-| Emoji-Lipsum    |  3.4       | 0.8                       | 4.3 x           |
-| Hebrew-Lipsum   |  3.4       | 2.0                       | 1.7 x           |
-| Hindi-Lipsum    |  3.4       | 1.6                       | 2.1 x           |
-| Japanese-Lipsum |  3.4       | 2.4                       | 1.4 x           |
-| Korean-Lipsum   |  3.4       | 1.3                       | 2.6 x           |
+| Twitter.json    |  14        | 8.7                        | 1.4 x           |
+| Arabic-Lipsum   |  4.2       | 2.0                       | 2.1 x           |
+| Chinese-Lipsum  |  4.2        | 2.6                       | 1.6 x           |
+| Emoji-Lipsum    |  4.2        | 0.8                       | 5.3 x           |
+| Hebrew-Lipsum   |  4.2        | 2.0                       | 2.1 x           |
+| Hindi-Lipsum    |  4.2        | 1.6                       | 2.6 x           |
+| Japanese-Lipsum |  4.2        | 2.4                       | 1.8 x           |
+| Korean-Lipsum   |  4.2        | 1.3                       | 3.2 x           |
 | Latin-Lipsum    |  42        | 17                        | 2.5 x           |
-| Russian-Lipsum  |  3.3       | 0.95                       | 3.5 x           |
+| Russian-Lipsum  |  4.2        | 0.95                       | 4.4 x           |
 
 
 On a Qualcomm 8cx gen3 (Windows Dev Kit 2023), we get roughly the same relative performance

--- a/README.md
+++ b/README.md
@@ -195,23 +195,23 @@ faster than the standard library.
 | Latin-Lipsum    |  42        | 17                        | 2.5 x           |
 | Russian-Lipsum  |  3.3       | 0.95                       | 3.5 x           |
 
-On a Neoverse N1 (Graviton 2), our validation function is up to three times
+On a Neoverse N1 (Graviton 2), our validation function is up to over three times
 faster than the standard library.
+
 
 | data set      | SimdUnicode speed (GB/s) | .NET speed (GB/s) |  speed up |
 |:----------------|:-----------|:--------------------------|:-------------------|
-| Twitter.json    |  7.0        | 5.7                        | 1.2 x           |
-| Arabic-Lipsum   |  2.2       | 0.9                       | 2.4 x           |
-| Chinese-Lipsum  |  2.1       | 1.8                       | 1.1 x           |
-| Emoji-Lipsum    |  1.8       | 0.7                       | 2.6 x           |
-| Hebrew-Lipsum   |  2.0       | 0.9                       | 2.2 x           |
-| Hindi-Lipsum    |  2.0       | 1.0                       | 2.0 x           |
-| Japanese-Lipsum |  2.1       | 1.7                       | 1.2 x           |
-| Korean-Lipsum   |  2.2       | 1.0                       | 2.2 x           |
-| Latin-Lipsum    |  24        | 13                        | 1.8 x           |
-| Russian-Lipsum  |  2.1      | 0.7                       | 3.0 x           |
+| Twitter.json    |  7.8        | 5.7                        | 1.4 x           |
+| Arabic-Lipsum   |  2.5       | 0.9                       | 2.8 x           |
+| Chinese-Lipsum  |  2.5       | 1.8                       | 1.4 x           |
+| Emoji-Lipsum    |  2.5       | 0.7                       | 3.6 x           |
+| Hebrew-Lipsum   |  2.5       | 0.9                       | 2.7 x           |
+| Hindi-Lipsum    |  2.3       | 1.0                       | 2.3 x           |
+| Japanese-Lipsum |  2.4       | 1.7                       | 1.4 x           |
+| Korean-Lipsum   |  2.5       | 1.0                       | 2.5 x           |
+| Latin-Lipsum    |  23        | 13                        | 1.8 x           |
+| Russian-Lipsum  |  2.3      | 0.7                       | 3.3 x           |
 
-One difficulty with ARM processors is that they have varied SIMD/NEON performance. For example, Neoverse N1 processors, not to be confused with the Neoverse V1 design used by AWS Graviton 3, have weak SIMD performance. Of course, one can pick and choose which approach is best and it is not necessary to apply SimdUnicode is all cases. We expect good performance on recent ARM-based Qualcomm processors.
 
 ## Building the library
 

--- a/README.md
+++ b/README.md
@@ -167,16 +167,16 @@ boost as the Neoverse V1.
 
 | data set      | SimdUnicode speed (GB/s) | .NET speed (GB/s) |  speed up |
 |:----------------|:-----------|:--------------------------|:-------------------|
-| Twitter.json    |  15        | 10                        | 1.5 x           |
-| Arabic-Lipsum   |  4.0       | 2.3                       | 1.7 x           |
-| Chinese-Lipsum  |  4.0       | 2.9                       | 1.4 x           |
-| Emoji-Lipsum    |  4.0       | 0.9                       | 4.4 x           |
-| Hebrew-Lipsum   |  4.0       | 2.3                       | 1.7 x           |
-| Hindi-Lipsum    |  4.0       | 1.9                       | 2.1 x           |
-| Japanese-Lipsum |  4.0       | 2.7                       | 1.5 x           |
-| Korean-Lipsum   |  4.0       | 1.5                       | 2.7 x           |
+| Twitter.json    |  17        | 10                        | 1.7 x           |
+| Arabic-Lipsum   |  5.0       | 2.3                       | 2.2 x           |
+| Chinese-Lipsum  |  5.0       | 2.9                       | 1.7 x           |
+| Emoji-Lipsum    |  5.0       | 0.9                       | 5.5 x           |
+| Hebrew-Lipsum   |  5.0       | 2.3                       | 2.2 x           |
+| Hindi-Lipsum    |  5.0       | 1.9                       | 2.6 x           |
+| Japanese-Lipsum |  5.0       | 2.7                       | 1.9 x           |
+| Korean-Lipsum   |  5.0       | 1.5                       | 3.3 x           |
 | Latin-Lipsum    |  50        | 20                       | 2.5 x           |
-| Russian-Lipsum  |  4.0       | 1.2                       | 3.3 x           |
+| Russian-Lipsum  |  5.0       | 1.2                       | 5.2 x           |
 
 
 On a Neoverse N1 (Graviton 2), our validation function is 1.3 to over four times

--- a/src/UTF8.cs
+++ b/src/UTF8.cs
@@ -1277,18 +1277,6 @@ namespace SimdUnicode
             }
             return GetPointerToFirstInvalidByteScalar(pInputBuffer + processedLength, inputLength - processedLength, out utf16CodeUnitCountAdjustment, out scalarCountAdjustment);
         }
-        public static void ToString(Vector128<byte> v)
-        {
-            Span<byte> b = stackalloc byte[16];
-            v.CopyTo(b);
-            Console.WriteLine(Convert.ToHexString(b));
-        }
-        public static void ToString(Vector128<sbyte> v)
-        {
-            Span<byte> b = stackalloc byte[16];
-            v.AsByte().CopyTo(b);
-            Console.WriteLine(Convert.ToHexString(b));
-        }
         public unsafe static byte* GetPointerToFirstInvalidByteArm64(byte* pInputBuffer, int inputLength, out int utf16CodeUnitCountAdjustment, out int scalarCountAdjustment)
         {
             int processedLength = 0;

--- a/src/UTF8.cs
+++ b/src/UTF8.cs
@@ -1277,7 +1277,18 @@ namespace SimdUnicode
             }
             return GetPointerToFirstInvalidByteScalar(pInputBuffer + processedLength, inputLength - processedLength, out utf16CodeUnitCountAdjustment, out scalarCountAdjustment);
         }
-
+        public static void ToString(Vector128<byte> v)
+        {
+            Span<byte> b = stackalloc byte[16];
+            v.CopyTo(b);
+            Console.WriteLine(Convert.ToHexString(b));
+        }
+        public static void ToString(Vector128<sbyte> v)
+        {
+            Span<byte> b = stackalloc byte[16];
+            v.AsByte().CopyTo(b);
+            Console.WriteLine(Convert.ToHexString(b));
+        }
         public unsafe static byte* GetPointerToFirstInvalidByteArm64(byte* pInputBuffer, int inputLength, out int utf16CodeUnitCountAdjustment, out int scalarCountAdjustment)
         {
             int processedLength = 0;
@@ -1360,18 +1371,31 @@ namespace SimdUnicode
                     // The block goes from processedLength to processedLength/16*16.
                     int contbytes = 0; // number of continuation bytes in the block
                     int n4 = 0; // number of 4-byte sequences that start in this block
+                    /////
+                    // Design:
+                    // Instead of updating n4 and contbytes continuously, we accumulate
+                    // the values in n4v and contv, while using overflowCounter to make
+                    // sure we do not overflow. This allows you to reach good performance
+                    // on systems where summing across vectors is slow.
+                    ////
+                    Vector128<sbyte> n4v = Vector128<sbyte>.Zero;
+                    Vector128<sbyte> contv = Vector128<sbyte>.Zero;
+                    int overflowCounter = 0;
                     for (; processedLength + 16 <= inputLength; processedLength += 16)
                     {
 
                         Vector128<byte> currentBlock = AdvSimd.LoadVector128(pInputBuffer + processedLength);
                         if ((currentBlock & v80) == Vector128<byte>.Zero)
-                        // We could also use (AdvSimd.Arm64.MaxAcross(currentBlock).ToScalar() <= 127) but it is slower on some
-                        // hardware.
                         {
                             // We have an ASCII block, no need to process it, but
                             // we need to check if the previous block was incomplete.
                             if (prevIncomplete != Vector128<byte>.Zero)
                             {
+                                contbytes += -AdvSimd.Arm64.AddAcrossWidening(contv).ToScalar();
+                                if (n4v != Vector128<sbyte>.Zero)
+                                {
+                                    n4 += -AdvSimd.Arm64.AddAcrossWidening(n4v).ToScalar();
+                                }
                                 int off = processedLength >= 3 ? processedLength - 3 : processedLength;
                                 byte* invalidBytePointer = SimdUnicode.UTF8.SimpleRewindAndValidateWithErrors(16 - 3, pInputBuffer + processedLength - 3, inputLength - processedLength + 3);
                                 // So the code is correct up to invalidBytePointer
@@ -1432,11 +1456,13 @@ namespace SimdUnicode
                             Vector128<byte> must23 = AdvSimd.Or(isThirdByte, isFourthByte);
                             Vector128<byte> must23As80 = AdvSimd.And(must23, v80);
                             Vector128<byte> error = AdvSimd.Xor(must23As80, sc);
-                            // AdvSimd.Arm64.MaxAcross(error) works, but it might be slower
-                            // than AdvSimd.Arm64.MaxAcross(Vector128.AsUInt32(error)) on some
-                            // hardware:
                             if (error != Vector128<byte>.Zero)
                             {
+                                contbytes += -AdvSimd.Arm64.AddAcrossWidening(contv).ToScalar();
+                                if (n4v != Vector128<sbyte>.Zero)
+                                {
+                                    n4 += -AdvSimd.Arm64.AddAcrossWidening(n4v).ToScalar();
+                                }
                                 byte* invalidBytePointer;
                                 if (processedLength == 0)
                                 {
@@ -1459,17 +1485,32 @@ namespace SimdUnicode
                                 return invalidBytePointer;
                             }
                             prevIncomplete = AdvSimd.SubtractSaturate(currentBlock, maxValue);
-                            contbytes += -AdvSimd.Arm64.AddAcross(AdvSimd.CompareLessThanOrEqual(Vector128.AsSByte(currentBlock), largestcont)).ToScalar();
-                            Vector128<byte> largerthan0f = AdvSimd.CompareGreaterThan(currentBlock, fourthByteMinusOne);
-                            if (largerthan0f != Vector128<byte>.Zero)
+                            contv += AdvSimd.CompareLessThanOrEqual(Vector128.AsSByte(currentBlock), largestcont);
+                            n4v += AdvSimd.CompareGreaterThan(currentBlock, fourthByteMinusOne).AsSByte();
+                            overflowCounter++;
+                            // We have a risk of overflow if overflowCounter reaches 255,
+                            // in which case, we empty contv and n4v, and update contbytes and
+                            // n4.
+                            if (overflowCounter == 0xff)
                             {
-                                byte n4add = (byte)AdvSimd.Arm64.AddAcross(largerthan0f).ToScalar();
-                                int negn4add = (int)(byte)-n4add;
-                                n4 += negn4add;
+                                overflowCounter = 0;
+                                contbytes += -AdvSimd.Arm64.AddAcrossWidening(contv).ToScalar();
+                                contv = Vector128<sbyte>.Zero;
+                                if (n4v != Vector128<sbyte>.Zero)
+                                {
+                                    n4 += -AdvSimd.Arm64.AddAcrossWidening(n4v).ToScalar();
+                                    n4v = Vector128<sbyte>.Zero;
+                                }
                             }
                         }
                     }
-                    bool hasIncompete = (prevIncomplete !=  Vector128<byte>.Zero);
+                    contbytes += -AdvSimd.Arm64.AddAcrossWidening(contv).ToScalar();
+                    if (n4v != Vector128<sbyte>.Zero)
+                    {
+                        n4 += -AdvSimd.Arm64.AddAcrossWidening(n4v).ToScalar();
+                    }
+
+                    bool hasIncompete = (prevIncomplete != Vector128<byte>.Zero);
                     if (processedLength < inputLength || hasIncompete)
                     {
                         byte* invalidBytePointer;


### PR DESCRIPTION
To optimize on weak ARM cores, I am using a graviton 2 from AWS. It is based on Neoverse N1. The trick is to do the sum across only once per string (or, once per blocks of ~4kB for long strings). 

New results on @EgorBo's data




|                              Method |                  FileName |      Mean |    Error |   StdDev | Speed (GB/s) |
|------------------------------------ |-------------------------- |----------:|---------:|---------:|------------- |
|          SIMDUtf8ValidationRealData | data/Bogatov1069.utf8.txt | 510.69 ns | 4.810 ns | 0.264 ns |         2.09 |
|          SIMDUtf8ValidationRealData |  data/Bogatov136.utf8.txt |  92.22 ns | 0.438 ns | 0.024 ns |         1.47 |
|          SIMDUtf8ValidationRealData |  data/Bogatov286.utf8.txt | 176.81 ns | 1.814 ns | 0.099 ns |         1.62 |
|          SIMDUtf8ValidationRealData |  data/Bogatov527.utf8.txt | 284.26 ns | 1.160 ns | 0.064 ns |         1.85 |

Old results on  @EgorBo's data

|                              Method |                  FileName |      Mean |    Error |   StdDev | Speed (GB/s) |
|------------------------------------ |-------------------------- |----------:|---------:|---------:|------------- |
|          SIMDUtf8ValidationRealData | data/Bogatov1069.utf8.txt | 576.68 ns | 89.757 ns | 4.920 ns |         1.85 |
|          SIMDUtf8ValidationRealData |  data/Bogatov136.utf8.txt |  98.05 ns |  4.872 ns | 0.267 ns |         1.39 |
|          SIMDUtf8ValidationRealData |  data/Bogatov286.utf8.txt | 193.19 ns | 13.463 ns | 0.738 ns |         1.48 |
|          SIMDUtf8ValidationRealData |  data/Bogatov527.utf8.txt | 318.96 ns | 11.377 ns | 0.624 ns |         1.65 |

New results on Twitter:


|                              Method |          FileName |      Mean |    Error |   StdDev | Speed (GB/s) |
|------------------------------------ |------------------ |----------:|---------:|---------:|------------- |
|          SIMDUtf8ValidationRealData | data/twitter.json |  81.39 us | 1.671 us | 0.092 us |         7.76 |

Old results on Twitter:


|                              Method |          FileName |      Mean |    Error |   StdDev | Speed (GB/s) |
|------------------------------------ |------------------ |----------:|---------:|---------:|------------- |
|          SIMDUtf8ValidationRealData | data/twitter.json |  90.52 us | 1.111 us | 0.061 us |         6.98 |

New results on Lipsum:


|                              Method |                      FileName |       Mean |     Error |    StdDev | Speed (GB/s) |
|------------------------------------ |------------------------------ |-----------:|----------:|----------:|------------- |
|          SIMDUtf8ValidationRealData |   data/Arabic-Lipsum.utf8.txt |  33.085 us | 0.0820 us | 0.0045 us |         2.47 |
|          SIMDUtf8ValidationRealData |  data/Chinese-Lipsum.utf8.txt |  28.135 us | 0.0356 us | 0.0020 us |         2.48 |
|          SIMDUtf8ValidationRealData |    data/Emoji-Lipsum.utf8.txt |  26.412 us | 0.0459 us | 0.0025 us |         2.48 |
|          SIMDUtf8ValidationRealData |   data/Hebrew-Lipsum.utf8.txt |  26.829 us | 0.2250 us | 0.0123 us |         2.48 |
|          SIMDUtf8ValidationRealData |    data/Hindi-Lipsum.utf8.txt |  37.910 us | 0.1988 us | 0.0109 us |         2.32 |
|          SIMDUtf8ValidationRealData | data/Japanese-Lipsum.utf8.txt |  27.758 us | 9.4075 us | 0.5157 us |         2.44 |
|          SIMDUtf8ValidationRealData |   data/Korean-Lipsum.utf8.txt |  26.945 us | 1.8570 us | 0.1018 us |         2.47 |
|          SIMDUtf8ValidationRealData |    data/Latin-Lipsum.utf8.txt |   3.737 us | 0.0205 us | 0.0011 us |        23.26 |
|          SIMDUtf8ValidationRealData |  data/Russian-Lipsum.utf8.txt |  45.083 us | 0.0307 us | 0.0017 us |         2.32 |

Old results on Lipsum:


|                              Method |                      FileName |       Mean |      Error |    StdDev | Speed (GB/s) |
|------------------------------------ |------------------------------ |-----------:|-----------:|----------:|------------- |
|          SIMDUtf8ValidationRealData |   data/Arabic-Lipsum.utf8.txt |  37.712 us |  0.1409 us | 0.0077 us |         2.17 |
|          SIMDUtf8ValidationRealData |  data/Chinese-Lipsum.utf8.txt |  33.545 us |  0.9888 us | 0.0542 us |         2.08 |
|          SIMDUtf8ValidationRealData |    data/Emoji-Lipsum.utf8.txt |  37.238 us |  0.1203 us | 0.0066 us |         1.76 |
|          SIMDUtf8ValidationRealData |   data/Hebrew-Lipsum.utf8.txt |  33.957 us |  0.0790 us | 0.0043 us |         1.96 |
|          SIMDUtf8ValidationRealData |    data/Hindi-Lipsum.utf8.txt |  44.110 us |  0.0708 us | 0.0039 us |         1.99 |
|          SIMDUtf8ValidationRealData | data/Japanese-Lipsum.utf8.txt |  32.090 us |  1.5966 us | 0.0875 us |         2.11 |
|          SIMDUtf8ValidationRealData |   data/Korean-Lipsum.utf8.txt |  30.836 us |  0.3372 us | 0.0185 us |         2.16 |
|          SIMDUtf8ValidationRealData |    data/Latin-Lipsum.utf8.txt |   3.687 us |  0.1805 us | 0.0099 us |        23.58 |
|          SIMDUtf8ValidationRealData |  data/Russian-Lipsum.utf8.txt |  50.254 us |  3.7907 us | 0.2078 us |         2.08 |


