### PR TITLE
another small correction

### DIFF
--- a/test/UTF8ValidationTests.cs
+++ b/test/UTF8ValidationTests.cs
@@ -50,7 +50,7 @@ public unsafe class Utf8SIMDValidationTests
             switch (RuntimeInformation.ProcessArchitecture)
             {
                 case Architecture.Arm64:
-                    return requiredSystems.HasFlag(TestSystemRequirements.Arm64);
+                    return requiredSystems.HasFlag(TestSystemRequirements.Arm64) && AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian;
                 case Architecture.X64:
                     return (requiredSystems.HasFlag(TestSystemRequirements.X64Avx512) && Vector512.IsHardwareAccelerated && System.Runtime.Intrinsics.X86.Avx512F.IsSupported) ||
                         (requiredSystems.HasFlag(TestSystemRequirements.X64Avx2) && System.Runtime.Intrinsics.X86.Avx2.IsSupported) ||

--- a/test/UTF8ValidationTests.cs
+++ b/test/UTF8ValidationTests.cs
@@ -54,7 +54,7 @@ public unsafe class Utf8SIMDValidationTests
                 case Architecture.X64:
                     return (requiredSystems.HasFlag(TestSystemRequirements.X64Avx512) && Vector512.IsHardwareAccelerated && System.Runtime.Intrinsics.X86.Avx512F.IsSupported) ||
                         (requiredSystems.HasFlag(TestSystemRequirements.X64Avx2) && System.Runtime.Intrinsics.X86.Avx2.IsSupported) ||
-                        (requiredSystems.HasFlag(TestSystemRequirements.X64Sse) && System.Runtime.Intrinsics.X86.Sse.IsSupported);
+                        (requiredSystems.HasFlag(TestSystemRequirements.X64Sse) && System.Runtime.Intrinsics.X86.Ssse3.IsSupported);
                 default:
                     return false; // If architecture is not covered above, the test is not supported.
             }


### PR DESCRIPTION
For the SSE tests, we require SSSE3 and not merely SSE.